### PR TITLE
Fix token validation and unauthorized page

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,10 @@
-nst express = require('express');
+const express = require('express');
 const app = express();
+// Ensure fetch is available across Node versions
+const fetchFn =
+  typeof fetch === 'function'
+    ? fetch
+    : (...args) => import('node-fetch').then(({ default: f }) => f(...args));
 
 const TOKEN_ENDPOINT = 'https://diploma.exoteach.com/medibox2-api/graphql';
 
@@ -10,7 +15,7 @@ app.get('/validate', async (req, res) => {
   }
 
   try {
-    const response = await fetch(TOKEN_ENDPOINT);
+    const response = await fetchFn(TOKEN_ENDPOINT);
     if (!response.ok) {
       console.error('Failed to fetch token', await response.text());
       return res.status(500).json({ ok: false });

--- a/unauthorized.html
+++ b/unauthorized.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Accès refusé</title>
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body class="is-preload">
+  <div id="wrapper">
+    <div id="main">
+      <div class="inner">
+        <header id="header">
+          <h1>Accès non autorisé</h1>
+        </header>
+        <p>Vous n'êtes pas autorisé à accéder à cette page.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- improve server.js so it starts correctly
- add a fallback fetch implementation for Node versions without the global `fetch`
- new `unauthorized.html` page shown when token validation fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685333417b9c832c942d60ae95bb754b