### PR TITLE
Add kidney and pelvis flashcard details

### DIFF
--- a/Anatomie_App/anatapp10.html
+++ b/Anatomie_App/anatapp10.html
@@ -82,7 +82,11 @@ const flashcardsData=[
 {question:"À quel niveau vertébral se projettent les hiles rénaux ?",answer:"Environ au niveau de L1-L2."},
 {question:"Quelle est la position relative de l'aorte et de la veine cave inférieure ?",answer:"L'aorte est paramédiane gauche et la veine cave paramédiane droite."},
 {question:"Quels sont les trois plans de collatérales de l'aorte abdominale ?",answer:"Des branches ventrales digestives, latérales rénales et dorsales pour la moelle."},
-{question:"Comment le péritoine pariétal recouvre-t-il la région postérieure ?",answer:"Il chemine de l'arrière vers l'avant avant de devenir péritoine viscéral."}
+{question:"Comment le péritoine pariétal recouvre-t-il la région postérieure ?",answer:"Il chemine de l'arrière vers l'avant avant de devenir péritoine viscéral."},
+{question:"Quel organe assure le stockage de l'urine ?",answer:"La vessie."},
+{question:"Dans quel vaisseau se jette la veine rénale ?",answer:"Dans la veine cave inférieure."},
+{question:"Lequel des deux reins est situé plus bas ?",answer:"Le rein droit est généralement plus bas que le rein gauche."},
+{question:"Quelle intervention chirurgicale réalise-t-on souvent sur le rein ?",answer:"La lobectomie."}
 ];
 const container=document.getElementById("flashcards");
 const progressBar=document.getElementById("progressBar");

--- a/Anatomie_App/anatapp11.html
+++ b/Anatomie_App/anatapp11.html
@@ -241,6 +241,15 @@ const flashcardsData =
   { question: "Quel cul-de-sac peritoneal est le plus declive chez la femme ?", answer: "Le cul-de-sac recto-uterin." },
   { question: "Ou se trouve l'ovaire ?", answer: "Dans une fosse para-rectale, recouvert de peritoine, donc intra-peritoneal." },
   { question: "Quel angle forment ampoule rectale et canal anal ?", answer: "Le cap anal." }
+  ,{ question: "Quelles branches donne l'artère iliaque interne ?", answer: "Des collatérales rectale, génitale et vésicale." }
+  ,{ question: "D'où proviennent les nerfs du plexus sacré ?", answer: "Des racines lombaires prolongees dans le canal sacré." }
+  ,{ question: "Quel muscle assure la flexion de la cuisse sur le bassin ?", answer: "Le muscle psoas-iliaque." }
+  ,{ question: "Quel rôle joue le muscle élévateur de l'anus ?", answer: "Il participe à la fermeture de l'ampoule rectale." }
+  ,{ question: "Quelle est la capacité approximative de la vessie ?", answer: "Environ 300 mL d'urine." }
+  ,{ question: "Par où les uretères s'abouchent-ils dans la vessie ?", answer: "Par les ostiums situés sur sa face postérieure." }
+  ,{ question: "Quelles composantes forme la prostate ?", answer: "Une partie crâniale et une partie caudale séparées par le conduit éjaculateur." }
+  ,{ question: "Quel plan fibreux sépare les filières génitale et rectale ?", answer: "Le centre tendineux du périnée." }
+  ,{ question: "Comment est orienté le vagin ?", answer: "Vers le haut et l'arrière." }
 ];
 const container = document.getElementById("flashcards");
 const progressBar = document.getElementById("progressBar");


### PR DESCRIPTION
## Summary
- expand kidney flashcards with urine storage, renal vein path and surgical note
- flesh out pelvis course flashcards with vascular, nervous and pelvic organ details

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685441531d0c832cbb28534ad229b44b