### PR TITLE
Align course titles and remove obsolete script

### DIFF
--- a/Anatomie_App/anatapp1.html
+++ b/Anatomie_App/anatapp1.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_App/anatapp10.html
+++ b/Anatomie_App/anatapp10.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
 <script src="/security.js" defer></script>
-<script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 <div id="wrapper">

--- a/Anatomie_App/anatapp11.html
+++ b/Anatomie_App/anatapp11.html
@@ -8,7 +8,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
     <script src="/security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_App/anatapp12.html
+++ b/Anatomie_App/anatapp12.html
@@ -8,7 +8,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
     <script src="/security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_App/anatapp13.html
+++ b/Anatomie_App/anatapp13.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="assets/css/main.css" />
     <script src="security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_App/anatapp2.html
+++ b/Anatomie_App/anatapp2.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
     <script src="/security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_App/anatapp3.html
+++ b/Anatomie_App/anatapp3.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
 <script src="/security.js" defer></script>
-<script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_App/anatapp4.html
+++ b/Anatomie_App/anatapp4.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
     <script src="/security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_App/anatapp5.html
+++ b/Anatomie_App/anatapp5.html
@@ -8,7 +8,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
     <script src="/security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 
@@ -495,7 +494,7 @@ updateProgress();
                         <li><a href="/Anatomie%20Socle/anat2.html">Ostéologie</a></li>
                         <li><a href="/Anatomie%20Socle/anat3.html">Arthrologie</a></li>
                         <li><a href="/Anatomie%20Socle/anat4.html">Myologie</a></li>
-                        <li><a href="/Anatomie%20Socle/anat5.html">Membres inférieurs Jambe/Pied</a></li>
+                        <li><a href="/Anatomie%20Socle/anat5.html">Jambe/Pied</a></li>
                         <li><a href="/Anatomie%20Socle/anat6.html">Membre supérieur</a></li>
                         <li><a href="/Anatomie%20Socle/anat7.html">Membre inférieur</a></li>
                         <li><a href="/Anatomie%20Socle/anat8.html">Cardiovasculaire et respiratoire</a></li>

--- a/Anatomie_App/anatapp6.html
+++ b/Anatomie_App/anatapp6.html
@@ -8,7 +8,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
     <script src="/security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_App/anatapp7.html
+++ b/Anatomie_App/anatapp7.html
@@ -8,7 +8,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
     <script src="/security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_App/anatapp8.html
+++ b/Anatomie_App/anatapp8.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="assets/css/main.css" />
 <script src="security.js" defer></script>
-<script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 <div id="wrapper">

--- a/Anatomie_App/anatapp9.html
+++ b/Anatomie_App/anatapp9.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="/assets/css/main.css" />
 <script src="/security.js" defer></script>
-<script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 <!-- Wrapper -->

--- a/Anatomie_Socle/anat1.html
+++ b/Anatomie_Socle/anat1.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat10.html
+++ b/Anatomie_Socle/anat10.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat11.html
+++ b/Anatomie_Socle/anat11.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat12.html
+++ b/Anatomie_Socle/anat12.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat2.html
+++ b/Anatomie_Socle/anat2.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat3.html
+++ b/Anatomie_Socle/anat3.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat4.html
+++ b/Anatomie_Socle/anat4.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat5.html
+++ b/Anatomie_Socle/anat5.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat6.html
+++ b/Anatomie_Socle/anat6.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat7.html
+++ b/Anatomie_Socle/anat7.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat8.html
+++ b/Anatomie_Socle/anat8.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Anatomie_Socle/anat9.html
+++ b/Anatomie_Socle/anat9.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_App/biochapp1.html
+++ b/Biochimie_App/biochapp1.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_App/biochapp2.html
+++ b/Biochimie_App/biochapp2.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_App/biochapp4.html
+++ b/Biochimie_App/biochapp4.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_App/biochapp5.html
+++ b/Biochimie_App/biochapp5.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_App/biochapp6.html
+++ b/Biochimie_App/biochapp6.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_App/biochapp7.html
+++ b/Biochimie_App/biochapp7.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_Socle/bioch1.html
+++ b/Biochimie_Socle/bioch1.html
@@ -6,7 +6,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="../assets/css/main.css" />
 	    <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 	<body class="is-preload">
 

--- a/Biochimie_Socle/bioch10.html
+++ b/Biochimie_Socle/bioch10.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_Socle/bioch11.html
+++ b/Biochimie_Socle/bioch11.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_Socle/bioch12.html
+++ b/Biochimie_Socle/bioch12.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_Socle/bioch13.html
+++ b/Biochimie_Socle/bioch13.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_Socle/bioch14.html
+++ b/Biochimie_Socle/bioch14.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_Socle/bioch15.html
+++ b/Biochimie_Socle/bioch15.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_Socle/bioch2.html
+++ b/Biochimie_Socle/bioch2.html
@@ -6,7 +6,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="../assets/css/main.css" />
 	    <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 	<body class="is-preload">
 

--- a/Biochimie_Socle/bioch3.html
+++ b/Biochimie_Socle/bioch3.html
@@ -6,7 +6,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="../assets/css/main.css" />
 	    <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 	<body class="is-preload">
 

--- a/Biochimie_Socle/bioch4.html
+++ b/Biochimie_Socle/bioch4.html
@@ -6,7 +6,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="../assets/css/main.css" />
 	    <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 	<body class="is-preload">
 

--- a/Biochimie_Socle/bioch5.html
+++ b/Biochimie_Socle/bioch5.html
@@ -6,7 +6,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="../assets/css/main.css" />
 	    <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 	<body class="is-preload">
 

--- a/Biochimie_Socle/bioch6.html
+++ b/Biochimie_Socle/bioch6.html
@@ -6,7 +6,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="../assets/css/main.css" />
 	    <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 	<body class="is-preload">
 

--- a/Biochimie_Socle/bioch7.html
+++ b/Biochimie_Socle/bioch7.html
@@ -6,7 +6,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="../assets/css/main.css" />
 	    <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 	<body class="is-preload">
 

--- a/Biochimie_Socle/bioch8.html
+++ b/Biochimie_Socle/bioch8.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biochimie_Socle/bioch9.html
+++ b/Biochimie_Socle/bioch9.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell1.html
+++ b/Biologie_Cellulaire/biocell1.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell10.html
+++ b/Biologie_Cellulaire/biocell10.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell11.html
+++ b/Biologie_Cellulaire/biocell11.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell13.html
+++ b/Biologie_Cellulaire/biocell13.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell14.html
+++ b/Biologie_Cellulaire/biocell14.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell15.html
+++ b/Biologie_Cellulaire/biocell15.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell16.html
+++ b/Biologie_Cellulaire/biocell16.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell17.html
+++ b/Biologie_Cellulaire/biocell17.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell18.html
+++ b/Biologie_Cellulaire/biocell18.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell2.html
+++ b/Biologie_Cellulaire/biocell2.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell3.html
+++ b/Biologie_Cellulaire/biocell3.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell4.html
+++ b/Biologie_Cellulaire/biocell4.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell5.html
+++ b/Biologie_Cellulaire/biocell5.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell7.html
+++ b/Biologie_Cellulaire/biocell7.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell8.html
+++ b/Biologie_Cellulaire/biocell8.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/Biologie_Cellulaire/biocell9.html
+++ b/Biologie_Cellulaire/biocell9.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/SHS_Socle/shs1.html
+++ b/SHS_Socle/shs1.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/SHS_Socle/shs2.html
+++ b/SHS_Socle/shs2.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/SHS_Socle/shs3.html
+++ b/SHS_Socle/shs3.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/SHS_Socle/shs4.html
+++ b/SHS_Socle/shs4.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/SHS_Socle/shs5.html
+++ b/SHS_Socle/shs5.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="../assets/css/main.css" />
     <script src="../security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 <body class="is-preload">
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 	    <script src="security.js" defer></script>
-    <script defer>authorizeFromToken().then(checkAccess);</script>
 </head>
 	<body class="is-preload">
 
@@ -201,15 +200,15 @@
                       <span class="opener">Anatomie App</span>
                       <ul>
                         <li><a href="Anatomie_App/anatapp1.html">Rachis</a></li>
-                        <li><a href="anatapp2.html">Epaule/Bras</a></li>
-                        <li><a href="anatapp3.html">Avant bras/Main</a></li>
-                        <li><a href="anatapp4.html">Hanche/Cuisse</a></li>
-                        <li><a href="anatapp5.html">Jambe/Pied</a></li>
-                        <li><a href="anatapp6.html">Appareil cardiovasculaire</a></li>
-                        <li><a href="anatapp7.html">Appareil respiratoire</a></li>
+                        <li><a href="Anatomie_App/anatapp2.html">Epaule/Bras</a></li>
+                        <li><a href="Anatomie_App/anatapp3.html">Avant bras/Main</a></li>
+                        <li><a href="Anatomie_App/anatapp4.html">Hanche/Cuisse</a></li>
+                        <li><a href="Anatomie_App/anatapp5.html">Jambe/Pied</a></li>
+                        <li><a href="Anatomie_App/anatapp6.html">Appareil cardiovasculaire</a></li>
+                        <li><a href="Anatomie_App/anatapp7.html">Appareil respiratoire</a></li>
                         <li><a href="Anatomie_App/anatapp8.html">Appareil digestif I</a></li>
-                        <li><a href="anatapp9.html">Appareil digestif II</a></li>
-                        <li><a href="anatapp10.html">Région pelvienne I (Haut)</a></li>
+                        <li><a href="Anatomie_App/anatapp9.html">Appareil digestif II</a></li>
+                        <li><a href="Anatomie_App/anatapp10.html">Région pelvienne I (Haut)</a></li>
                         <li><a href="Anatomie_App/anatapp11.html">Région pelvienne II (Bas)</a></li>
                         <li><a href="Anatomie_App/anatapp12.html">Région cervicale</a></li>
                         <li><a href="Anatomie_App/anatapp13.html">Système nerveux</a></li>


### PR DESCRIPTION
## Summary
- remove obsolete checkAccess script call on every page
- update anatomical course headings to match the sidebar titles
- fix links for anatomy app menu
- restore previous anatomy course titles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854443fe234832caf1b990e3df491e6