### PR TITLE
Implement token invalidation

### DIFF
--- a/security.js
+++ b/security.js
@@ -31,6 +31,24 @@ async function verifierToken() {
     return;
   }
 
+  // Validation supplémentaire auprès de notre serveur pour s'assurer que
+  // le token correspond bien au dernier utilisé par cet utilisateur.
+  try {
+    const validRes = await fetch(`/validate?token=${encodeURIComponent(token)}`);
+    const validJson = await validRes.json();
+    if (!validJson.ok) {
+      console.warn("❌ Token obsolète ou invalide :", validJson.reason);
+      localStorage.removeItem("jwtToken");
+      window.location.href = "unauthorized.html";
+      return;
+    }
+  } catch (err) {
+    console.error("❌ Erreur de validation du token :", err);
+    localStorage.removeItem("jwtToken");
+    window.location.href = "unauthorized.html";
+    return;
+  }
+
   try {
     const response = await fetch("https://diploma.exoteach.com/medibox2-api/graphql", {
       method: "POST",


### PR DESCRIPTION
## Summary
- keep track of the latest token in `server.js`
- reject obsolete tokens in `/validate`
- verify the token with `/validate` from `security.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855c14ed880832c98e43c3cadfa1583