### PR TITLE
Fix token validation with new tokens

### DIFF
--- a/server.js
+++ b/server.js
@@ -51,7 +51,9 @@ app.get('/validate', async (req, res) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Token': EXOATECH_TOKEN,
+        // On utilise le token fourni par le client pour vérifier qu'il est
+        // toujours accepté par l'API Exoatech.
+        'X-Token': token,
       },
       body: JSON.stringify({
         query: `query { me { id email username } }`


### PR DESCRIPTION
## Summary
- validate JWT tokens by calling Exoatech API with the provided token

## Testing
- `npm test --silent` *(fails: Error: no test specified)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6855c3476a34832cb0a9c5f22c3c8e5f