### PR TITLE
Add basic unit tests

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -1,0 +1,11 @@
+function decodeJWT(token) {
+  try {
+    const base64Payload = token.split('.')[1];
+    const jsonPayload = Buffer.from(base64Payload, 'base64').toString();
+    return JSON.parse(jsonPayload);
+  } catch (e) {
+    return null;
+  }
+}
+
+module.exports = { decodeJWT };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "express": "^4.21.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test.js",
     "start": "node server.js"
   },
   "keywords": [],

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const url = require('url');
+const { decodeJWT } = require('./decode');
 
 const fetchFn = typeof fetch === 'function'
   ? fetch
@@ -12,16 +13,6 @@ const TOKEN_ENDPOINT = 'https://diploma.exoteach.com/medibox2-api/graphql';
 // Dictionnaire pour garder en mémoire le dernier token valide pour chaque
 // utilisateur. Lorsqu'un nouveau token est validé, l'ancien devient obsolète.
 const latestTokens = {};
-
-function decodeJWT(token) {
-  try {
-    const base64Payload = token.split('.')[1];
-    const jsonPayload = Buffer.from(base64Payload, 'base64').toString();
-    return JSON.parse(jsonPayload);
-  } catch (e) {
-    return null;
-  }
-}
 
 function sendJSON(res, status, obj) {
   res.writeHead(status, { 'Content-Type': 'application/json' });
@@ -151,6 +142,10 @@ const server = http.createServer((req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () => {
-  console.log(`✅ Serveur lancé sur http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`✅ Serveur lancé sur http://localhost:${PORT}`);
+  });
+}
+
+module.exports = { server };

--- a/test.js
+++ b/test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { decodeJWT } = require('./decode');
+
+function testDecodeValid() {
+  const payload = { id: 123, name: 'test' };
+  const base64 = Buffer.from(JSON.stringify(payload)).toString('base64');
+  const token = `header.${base64}.signature`;
+  const decoded = decodeJWT(token);
+  assert.deepStrictEqual(decoded, payload);
+}
+
+function testDecodeInvalid() {
+  const decoded = decodeJWT('invalid.token');
+  assert.strictEqual(decoded, null);
+}
+
+try {
+  testDecodeValid();
+  testDecodeInvalid();
+  console.log('All tests passed');
+} catch (err) {
+  console.error('Test failed');
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- export token decoding helper in a new module
- refactor server.js to use the helper and only start when run directly
- provide a basic test script for decodeJWT
- update `npm test` to run the test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855cec85b7c832c9bd3031148ae6d26