### PR TITLE
Improve JWT expiry validation

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -8,4 +8,11 @@ function decodeJWT(token) {
   }
 }
 
-module.exports = { decodeJWT };
+function isTokenExpired(decoded) {
+  if (!decoded || typeof decoded.exp !== 'number') {
+    return true;
+  }
+  return decoded.exp * 1000 < Date.now();
+}
+
+module.exports = { decodeJWT, isTokenExpired };

--- a/security.js
+++ b/security.js
@@ -46,6 +46,12 @@ async function verifierToken() {
     return;
   }
 
+  if (typeof decoded.exp === "number" && decoded.exp * 1000 < Date.now()) {
+    console.warn("❌ Token expir\u00e9.");
+    window.location.href = "unauthorized.html";
+    return;
+  }
+
   // Aucune validation réseau n'est effectuée pour permettre l'utilisation hors ligne.
   console.log("✅ Token détecté :", decoded);
 }

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const url = require('url');
-const { decodeJWT } = require('./decode');
+const { decodeJWT, isTokenExpired } = require('./decode');
 
 const fetchFn = typeof fetch === 'function'
   ? fetch
@@ -23,6 +23,15 @@ async function handleValidate(req, res, query) {
   const token = query.token;
   const decoded = decodeJWT(token);
   const clientId = decoded?.id?.toString();
+
+  if (isTokenExpired(decoded)) {
+    sendJSON(res, 200, {
+      ok: false,
+      reason: 'Token expir\u00e9',
+      tokenClient: token
+    });
+    return;
+  }
 
   if (!token || !decoded || !clientId) {
     sendJSON(res, 200, {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { decodeJWT } = require('./decode');
+const { decodeJWT, isTokenExpired } = require('./decode');
 
 function testDecodeValid() {
   const payload = { id: 123, name: 'test' };
@@ -14,9 +14,24 @@ function testDecodeInvalid() {
   assert.strictEqual(decoded, null);
 }
 
+function testTokenExpiry() {
+  const expiredPayload = { id: 1, exp: Math.floor(Date.now() / 1000) - 10 };
+  const expiredBase64 = Buffer.from(JSON.stringify(expiredPayload)).toString('base64');
+  const expiredToken = `h.${expiredBase64}.s`;
+  const decodedExpired = decodeJWT(expiredToken);
+  assert.strictEqual(isTokenExpired(decodedExpired), true);
+
+  const validPayload = { id: 1, exp: Math.floor(Date.now() / 1000) + 10 };
+  const validBase64 = Buffer.from(JSON.stringify(validPayload)).toString('base64');
+  const validToken = `h.${validBase64}.s`;
+  const decodedValid = decodeJWT(validToken);
+  assert.strictEqual(isTokenExpired(decodedValid), false);
+}
+
 try {
   testDecodeValid();
   testDecodeInvalid();
+  testTokenExpiry();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed');


### PR DESCRIPTION
## Summary
- add `isTokenExpired` helper
- verify token expiry server side and client side
- test token expiry scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d08fff24832c9db717c91c625fca