### PR TITLE
Fix token security validation

### DIFF
--- a/security.js
+++ b/security.js
@@ -47,13 +47,26 @@ async function verifierToken() {
   }
 
   if (typeof decoded.exp === "number" && decoded.exp * 1000 < Date.now()) {
-    console.warn("❌ Token expir\u00e9.");
+    console.warn("❌ Token expiré.");
     window.location.href = "unauthorized.html";
     return;
   }
 
-  // Aucune validation réseau n'est effectuée pour permettre l'utilisation hors ligne.
-  console.log("✅ Token détecté :", decoded);
+  try {
+    const resp = await fetch(`/validate?token=${encodeURIComponent(token)}`);
+    const json = await resp.json();
+    if (!json.ok) {
+      console.warn("❌ Token refusé :", json.reason);
+      window.location.href = "unauthorized.html";
+      return;
+    }
+  } catch (err) {
+    console.warn("❌ Erreur de validation du token:", err);
+    window.location.href = "unauthorized.html";
+    return;
+  }
+
+  console.log("✅ Token détecté et validé :", decoded);
 }
 
 // ▶️ Lancer la vérification au chargement

--- a/server.js
+++ b/server.js
@@ -4,9 +4,13 @@ const path = require('path');
 const url = require('url');
 const { decodeJWT, isTokenExpired } = require('./decode');
 
-const fetchFn = typeof fetch === 'function'
+let fetchFn = typeof fetch === 'function'
   ? fetch
   : (...args) => import('node-fetch').then(({ default: f }) => f(...args));
+
+function setFetch(fn) {
+  fetchFn = fn;
+}
 
 const TOKEN_ENDPOINT = 'https://diploma.exoteach.com/medibox2-api/graphql';
 
@@ -157,4 +161,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { server };
+module.exports = { server, setFetch };

--- a/test.js
+++ b/test.js
@@ -28,13 +28,59 @@ function testTokenExpiry() {
   assert.strictEqual(isTokenExpired(decodedValid), false);
 }
 
-try {
+const http = require('http');
+const { server, setFetch } = require('./server');
+
+function createToken(payload) {
+  const base64 = Buffer.from(JSON.stringify(payload)).toString('base64');
+  return `h.${base64}.s`;
+}
+
+function startServer() {
+  return new Promise((resolve) => {
+    const srv = server.listen(0, () => resolve(srv));
+  });
+}
+
+function requestValidate(srv, token) {
+  const port = srv.address().port;
+  return new Promise((resolve, reject) => {
+    http.get(`http://localhost:${port}/validate?token=${encodeURIComponent(token)}`,
+      res => {
+        let data = '';
+        res.on('data', chunk => data += chunk);
+        res.on('end', () => resolve(JSON.parse(data)));
+      })
+      .on('error', reject);
+  });
+}
+
+async function testValidate(okExpected) {
+  const payload = { id: 123, exp: Math.floor(Date.now() / 1000) + 60 };
+  const token = createToken(payload);
+  const srv = await startServer();
+  setFetch(async () => ({
+    json: async () => ({ data: { me: { id: okExpected ? '123' : '999' } } })
+  }));
+
+  const result = await requestValidate(srv, token);
+  srv.close();
+  setFetch(undefined);
+  assert.strictEqual(result.ok, okExpected);
+}
+
+async function runTests() {
   testDecodeValid();
   testDecodeInvalid();
   testTokenExpiry();
+  await testValidate(true);
+  await testValidate(false);
+}
+
+runTests().then(() => {
   console.log('All tests passed');
-} catch (err) {
+}).catch(err => {
   console.error('Test failed');
   console.error(err);
   process.exit(1);
-}
+});


### PR DESCRIPTION
## Summary
- validate JWTs with the `/validate` endpoint in `security.js`
- allow injecting a custom fetch function in `server.js` for tests
- extend `test.js` with server validation tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d408181c832c9ab1147459959be2