### PR TITLE
Update stéréochimie deck

### DIFF
--- a/Chimie_Socle/chimie2.html
+++ b/Chimie_Socle/chimie2.html
@@ -297,7 +297,9 @@ function createContent(content) {
     img.src = content.src;
     img.alt = content.alt || "";
     img.style.maxWidth = "100%";
+    img.style.maxHeight = "100%";
     img.style.height = "auto";
+    img.style.objectFit = "contain";
 
     wrapper.appendChild(img);
     return wrapper;

--- a/images/ex8_ethane.svg
+++ b/images/ex8_ethane.svg
@@ -1,10 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="220" height="80" font-family="Arial" font-size="14">
-  <text x="10" y="30">Eclipsée</text>
-  <line x1="10" y1="40" x2="40" y2="40" stroke="black"/>
-  <line x1="25" y1="40" x2="25" y2="60" stroke="black"/>
-  <circle cx="25" cy="40" r="5" fill="black"/>
-  <text x="120" y="30">Décalée</text>
-  <line x1="120" y1="40" x2="150" y2="40" stroke="black"/>
-  <line x1="135" y1="40" x2="135" y2="60" stroke="black"/>
-  <circle cx="135" cy="40" r="5" fill="black"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="120" font-family="Arial" font-size="12" stroke="black" fill="none">
+  <g transform="translate(0,0)">
+    <text x="20" y="15">Eclipsée</text>
+    <circle cx="40" cy="60" r="20"/>
+    <line x1="40" y1="60" x2="40" y2="30"/>
+    <text x="35" y="25">H</text>
+    <line x1="40" y1="60" x2="60" y2="80"/>
+    <text x="65" y="85">H</text>
+    <line x1="40" y1="60" x2="20" y2="80"/>
+    <text x="10" y="85">H</text>
+    <line x1="40" y1="60" x2="40" y2="30" stroke-dasharray="3,3"/>
+    <line x1="40" y1="60" x2="60" y2="80" stroke-dasharray="3,3"/>
+    <line x1="40" y1="60" x2="20" y2="80" stroke-dasharray="3,3"/>
+  </g>
+  <g transform="translate(120,0)">
+    <text x="20" y="15">Décalée</text>
+    <circle cx="40" cy="60" r="20"/>
+    <line x1="40" y1="60" x2="40" y2="30"/>
+    <text x="35" y="25">H</text>
+    <line x1="40" y1="60" x2="60" y2="80"/>
+    <text x="65" y="85">H</text>
+    <line x1="40" y1="60" x2="20" y2="80"/>
+    <text x="10" y="85">H</text>
+    <line x1="40" y1="60" x2="60" y2="40" stroke-dasharray="3,3"/>
+    <line x1="40" y1="60" x2="40" y2="90" stroke-dasharray="3,3"/>
+    <line x1="40" y1="60" x2="20" y2="40" stroke-dasharray="3,3"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- scale images properly inside flashcards
- redraw eclipsed vs staggered ethane diagram

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d411469c832c8d2f7569acac53a7