### PR TITLE
Fix stereochemistry flashcard and shrink Fischer diagrams

### DIFF
--- a/Chimie_Socle/chimie2.html
+++ b/Chimie_Socle/chimie2.html
@@ -245,7 +245,7 @@
 { question: "Quelles sont les deux formes d’anomères ?", answer: "Forme α (OH en bas en C1) et forme β (OH en haut en C1)", },
 { question: { type: "image", src: "../images/ex1_isomerie.svg", alt: "Molécules A et B", caption: "Quel est le type d’isomérie entre A et B ?" }, answer: "Isomérie de position (isomères de constitution)" },
 { question: { type: "image", src: "../images/ex2_ch3chclcooh.svg", alt: "CH3-CHCl-COOH", caption: "Cette molécule possède-t-elle un carbone asymétrique ?" }, answer: "Oui, le carbone portant Cl est chiral (4 substituants différents)" },
-{ question: { type: "image", src: "../images/ex3_ch3chohcl.svg", alt: "CH3-CH(OH)-Cl", caption: "Déterminer la configuration absolue (H en arrière)" }, answer: "Configuration R" },
+{ question: { type: "image", src: "../images/ex3_ch3chohcl.svg", alt: "CH3-CH(OH)-Cl", caption: "Déterminer la configuration absolue (H en arrière)" }, answer: "Configuration S" },
 { question: { type: "image", src: "../images/ex4_but2ene.svg", alt: "CH3-CH=CH-CH3", caption: "Existe-t-il une isomérie géométrique ?" }, answer: "Oui, ce composé présente des isomères Z et E" },
 { question: { type: "image", src: "../images/ex5_fischer_DL.svg", alt: "Représentation de Fischer", caption: "OH du carbone le plus bas à droite : série ?" }, answer: "Série D" },
 { question: { type: "image", src: "../images/ex6_fischer_asym.svg", alt: "Fischer asymétrique", caption: "Le carbone central est-il asymétrique ? Configuration ?" }, answer: "Oui, configuration S" },

--- a/images/ex5_fischer_DL.svg
+++ b/images/ex5_fischer_DL.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="120" height="160" stroke="black" fill="none">
-  <line x1="60" y1="20" x2="60" y2="140" stroke="black"/>
-  <line x1="30" y1="60" x2="90" y2="60" stroke="black"/>
-  <line x1="30" y1="100" x2="90" y2="100" stroke="black"/>
-  <text x="95" y="105" font-size="14" font-family="Arial">OH</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="120" stroke="black" fill="none">
+  <line x1="45" y1="15" x2="45" y2="105" stroke="black"/>
+  <line x1="22.5" y1="45" x2="67.5" y2="45" stroke="black"/>
+  <line x1="22.5" y1="75" x2="67.5" y2="75" stroke="black"/>
+  <text x="71.25" y="78.75" font-size="10" font-family="Arial">OH</text>
 </svg>

--- a/images/ex6_fischer_asym.svg
+++ b/images/ex6_fischer_asym.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="140" height="160" stroke="black" fill="none">
-  <line x1="70" y1="20" x2="70" y2="140" stroke="black"/>
-  <line x1="40" y1="80" x2="100" y2="80" stroke="black"/>
-  <text x="60" y="15" font-size="14" font-family="Arial">CH3</text>
-  <text x="60" y="155" font-size="14" font-family="Arial">H</text>
-  <text x="15" y="85" font-size="14" font-family="Arial">OH</text>
-  <text x="105" y="85" font-size="14" font-family="Arial">Cl</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="105" height="120" stroke="black" fill="none">
+  <line x1="52.5" y1="15" x2="52.5" y2="105" stroke="black"/>
+  <line x1="30" y1="60" x2="75" y2="60" stroke="black"/>
+  <text x="45" y="11.25" font-size="10" font-family="Arial">CH3</text>
+  <text x="45" y="116.25" font-size="10" font-family="Arial">H</text>
+  <text x="11.25" y="63.75" font-size="10" font-family="Arial">OH</text>
+  <text x="78.75" y="63.75" font-size="10" font-family="Arial">Cl</text>
 </svg>


### PR DESCRIPTION
## Summary
- correct stereochemistry answer (R -> S) in `chimie2.html`
- reduce size of Fischer diagram SVGs so they fit in the flashcards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e1feae74832cb89a6bf110341bed