### PR TITLE
Fix biochimie label in chimie pages

### DIFF
--- a/Chimie_Socle/chimie1.html
+++ b/Chimie_Socle/chimie1.html
@@ -430,7 +430,7 @@ updateProgress();
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
                     <li>
-                      <span class="opener">Chimie Socle</span>
+                      <span class="opener">Biochimie Socle</span>
                       <ul>
                          <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>
                         <li><a href="../Biochimie_Socle/bioch2.html">Structure et propriétés des protéines</a></li>

--- a/Chimie_Socle/chimie2.html
+++ b/Chimie_Socle/chimie2.html
@@ -423,7 +423,7 @@ updateProgress();
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
                     <li>
-                      <span class="opener">Chimie Socle</span>
+                      <span class="opener">Biochimie Socle</span>
                       <ul>
                          <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>
                         <li><a href="../Biochimie_Socle/bioch2.html">Structure et propriétés des protéines</a></li>

--- a/Chimie_Socle/chimie3.html
+++ b/Chimie_Socle/chimie3.html
@@ -426,7 +426,7 @@ updateProgress();
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
                     <li>
-                      <span class="opener">Chimie Socle</span>
+                      <span class="opener">Biochimie Socle</span>
                       <ul>
                          <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>
                         <li><a href="../Biochimie_Socle/bioch2.html">Structure et propriétés des protéines</a></li>

--- a/Chimie_Socle/chimie4.html
+++ b/Chimie_Socle/chimie4.html
@@ -418,7 +418,7 @@ updateProgress();
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
                     <li>
-                      <span class="opener">Chimie Socle</span>
+                      <span class="opener">Biochimie Socle</span>
                       <ul>
                          <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>
                         <li><a href="../Biochimie_Socle/bioch2.html">Structure et propriétés des protéines</a></li>

--- a/Chimie_Socle/chimie5.html
+++ b/Chimie_Socle/chimie5.html
@@ -362,7 +362,7 @@ updateProgress();
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
                     <li>
-                      <span class="opener">Chimie Socle</span>
+                      <span class="opener">Biochimie Socle</span>
                       <ul>
                          <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>
                         <li><a href="../Biochimie_Socle/bioch2.html">Structure et propriétés des protéines</a></li>

--- a/Chimie_Socle/chimie6.html
+++ b/Chimie_Socle/chimie6.html
@@ -362,7 +362,7 @@ updateProgress();
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
                     <li>
-                      <span class="opener">Chimie Socle</span>
+                      <span class="opener">Biochimie Socle</span>
                       <ul>
                          <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>
                         <li><a href="../Biochimie_Socle/bioch2.html">Structure et propriétés des protéines</a></li>

--- a/Chimie_Socle/chimie7.html
+++ b/Chimie_Socle/chimie7.html
@@ -362,7 +362,7 @@ updateProgress();
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
                     <li>
-                      <span class="opener">Chimie Socle</span>
+                      <span class="opener">Biochimie Socle</span>
                       <ul>
                          <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>
                         <li><a href="../Biochimie_Socle/bioch2.html">Structure et propriétés des protéines</a></li>

--- a/Chimie_Socle/chimie8.html
+++ b/Chimie_Socle/chimie8.html
@@ -362,7 +362,7 @@ updateProgress();
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
                     <li>
-                      <span class="opener">Chimie Socle</span>
+                      <span class="opener">Biochimie Socle</span>
                       <ul>
                          <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>
                         <li><a href="../Biochimie_Socle/bioch2.html">Structure et propriétés des protéines</a></li>

--- a/Chimie_Socle/chimie9.html
+++ b/Chimie_Socle/chimie9.html
@@ -362,7 +362,7 @@ updateProgress();
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
                     <li>
-                      <span class="opener">Chimie Socle</span>
+                      <span class="opener">Biochimie Socle</span>
                       <ul>
                          <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>
                         <li><a href="../Biochimie_Socle/bioch2.html">Structure et propriétés des protéines</a></li>


### PR DESCRIPTION
## Summary
- correct sidebar label from "Chimie Socle" to "Biochimie Socle" on chemistry course pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571318529c832c9ec60f963e6fad87