### PR TITLE
Fix token obsolescence check

### DIFF
--- a/server.express.js
+++ b/server.express.js
@@ -69,7 +69,7 @@ app.get('/validate', async (req, res) => {
       const current = latestTokens[clientId];
       if (current && current !== token) {
         const currentDecoded = decodeJWT(current);
-        if (currentDecoded?.exp && decoded.exp <= currentDecoded.exp) {
+        if (currentDecoded?.exp && decoded.exp < currentDecoded.exp) {
           return res.json({
             ok: false,
             reason: 'Token obsol\u00e8te',


### PR DESCRIPTION
## Summary
- correct comparison so a new token isn't flagged obsolete when expiry is unchanged

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68573a572974832cbae9c3b0bbf5e93f