### PR TITLE
Fix token obsolète

### DIFF
--- a/server.express.js
+++ b/server.express.js
@@ -69,7 +69,8 @@ app.get('/validate', async (req, res) => {
       const current = latestTokens[clientId];
       if (current && current !== token) {
         const currentDecoded = decodeJWT(current);
-        if (currentDecoded?.exp && decoded.exp < currentDecoded.exp) {
+        // Utiliser la date d'émission (iat) pour déterminer quel token est le plus récent
+        if (currentDecoded?.iat && decoded.iat && decoded.iat <= currentDecoded.iat) {
           return res.json({
             ok: false,
             reason: 'Token obsol\u00e8te',


### PR DESCRIPTION
## Summary
- fix token validation in `server.express.js` by comparing the `iat` timestamp instead of `exp`

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6857b2105590832cb8d88c8acb61322e