### PR TITLE
Fix JWT decoding for url-encoded tokens

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -1,7 +1,15 @@
+function base64UrlToBase64(str) {
+  str = str.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = str.length % 4;
+  if (pad) str += '='.repeat(4 - pad);
+  return str;
+}
+
 function decodeJWT(token) {
   try {
     const base64Payload = token.split('.')[1];
-    const jsonPayload = Buffer.from(base64Payload, 'base64').toString();
+    const base64 = base64UrlToBase64(base64Payload);
+    const jsonPayload = Buffer.from(base64, 'base64').toString();
     return JSON.parse(jsonPayload);
   } catch (e) {
     return null;

--- a/security.js
+++ b/security.js
@@ -1,7 +1,15 @@
+function base64UrlToBase64(str) {
+  str = str.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = str.length % 4;
+  if (pad) str += '='.repeat(4 - pad);
+  return str;
+}
+
 function decodeJWT(token) {
   try {
     const base64Payload = token.split(".")[1];
-    const jsonPayload = atob(base64Payload);
+    const base64 = base64UrlToBase64(base64Payload);
+    const jsonPayload = atob(base64);
     return JSON.parse(jsonPayload);
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- support base64url tokens by normalising before decoding
- update browser-side helper accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857bddf6a2c832cb8b3746eb07bd81d