### PR TITLE
Fix globe icon color

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2091,6 +2091,12 @@ button,
     font-size: 1.125em; }
   #header .icons {
     text-align: right; }
+  #header .icons a {
+    color: #ffffff;
+  }
+  #header .icons a:hover {
+    color: #00aeef;
+  }
   @media screen and (max-width: 1680px) {
     #header {
       padding-top: 5em; } }


### PR DESCRIPTION
## Summary
- ensure header globe icon is visible by default
- highlight with blue color on hover

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857bf7f15b0832c9a75c25527b326f2