### PR TITLE
Support tokens using 'sub' claim

### DIFF
--- a/security.js
+++ b/security.js
@@ -41,6 +41,12 @@ async function verifierToken() {
     window.location.href = "unauthorized.html";
     return;
   }
+  const clientId = (decoded?.id ?? decoded?.sub)?.toString();
+  if (!clientId) {
+    console.warn("❌ Token sans identifiant utilisateur.");
+    window.location.href = "unauthorized.html";
+    return;
+  }
 
   if (typeof decoded.exp === "number" && decoded.exp * 1000 < Date.now()) {
     console.warn("❌ Token expiré.");

--- a/server.js
+++ b/server.js
@@ -80,7 +80,7 @@ async function handleValidate(req, res, query) {
   }
 
   let decoded = decodeJWT(token);
-  const clientId = decoded?.id?.toString();
+  const clientId = (decoded?.id ?? decoded?.sub)?.toString();
 
   const record = validTokens.get(token);
   if (record && Date.now() > record.expiresAt) {

--- a/test.js
+++ b/test.js
@@ -79,6 +79,20 @@ async function testValidate(okExpected) {
   assert.strictEqual(result.ok, okExpected);
 }
 
+async function testValidateSub() {
+  const payload = { sub: 321, exp: Math.floor(Date.now() / 1000) + 60 };
+  const token = createToken(payload);
+  const srv = await startServer();
+  setFetch(async () => ({
+    json: async () => ({ data: { me: { id: '321' } } })
+  }));
+
+  const result = await requestValidate(srv, token);
+  srv.close();
+  setFetch(undefined);
+  assert.strictEqual(result.ok, true);
+}
+
 async function testValidateExpiry() {
   const payload = { id: 123, exp: Math.floor(Date.now() / 1000) + 60 };
   const token = createToken(payload);
@@ -150,6 +164,7 @@ async function runTests() {
   testDecodeInvalid();
   testTokenExpiry();
   await testValidate(true);
+  await testValidateSub();
   await testValidate(false);
   await testValidateExpiry();
   await testTokenReplacement();


### PR DESCRIPTION
## Summary
- allow tokens that include `sub` as user identifier
- enforce same check on the client
- add tests for `sub` payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c5fe1334832cb7198ab54997d41e