### PR TITLE
Improve styling for index page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2349,3 +2349,17 @@ body.dark-mode .flashcard-front {
 body.dark-mode .flashcard-front {
   box-shadow: inset 0 0 40px rgba(144, 202, 249, 0.15);
 }
+/* Custom styling for subject icons */
+.features article .icon {
+  background: linear-gradient(135deg, #6ec1e4, #00aeef);
+  border-radius: 50%;
+}
+.features article .icon:before {
+  color: #ffffff;
+}
+.features article .icon:after {
+  display: none;
+}
+body.dark-mode .features article .icon {
+  background: linear-gradient(135deg, #2196f3, #1565c0);
+}

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 									</header>
 									<div class="features">
 										<article>
-											<span class="icon solid fa-vial"></span>
+                                                                               <span class="icon solid fa-flask"></span>
 											<div class="content">
 												<h3>Biochimie</h3>
 												<ul class="actions">
@@ -57,7 +57,7 @@
 											</div>
 										</article>
 										<article>
-											<span class="icon solid fa-virus"></span>
+                                                                               <span class="icon solid fa-dna"></span>
 											<div class="content">
 												<h3>Biologie cellulaire</h3>
 												<ul class="actions">
@@ -66,7 +66,7 @@
 											</div>
 										</article>
 										<article>
-											<span class="icon solid fa-users"></span>
+                                                                               <span class="icon solid fa-book-open"></span>
 											<div class="content">
 												<h3>Sciences humaines et sociales</h3>
 												<ul class="actions">
@@ -75,7 +75,7 @@
 											</div>
 										</article>
 										<article>
-											<span class="icon solid fa-bone"></span>
+                                                                               <span class="icon solid fa-user-md"></span>
 											<div class="content">
 												<h3>Anatomie</h3>
 												<ul class="actions">


### PR DESCRIPTION
## Summary
- refresh index icons with modern Font Awesome choices
- add gradient and circular icon styles for subjects
- support dark mode for new icon styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857d50e0af0832c9de047a650bca4a1