### PR TITLE
Allow new tokens to replace old ones

### DIFF
--- a/server.js
+++ b/server.js
@@ -146,20 +146,14 @@ async function handleValidate(req, res, query) {
     if (valid) {
       const newTime = getTokenTime(decoded);
       const current = latestTokens[clientId];
-      if (current) {
-        if (newTime > current.time) {
-          if (current.token !== token) {
-            revokeToken(current.token);
-          }
-          latestTokens[clientId] = { token, time: newTime };
-        } else if (current.token !== token) {
-          sendJSON(res, 200, { ok: false, reason: 'Token obsolète' });
-          return;
-        }
-      } else {
-        latestTokens[clientId] = { token, time: newTime };
+      if (current && current.token !== token) {
+        revokeToken(current.token);
       }
-      validTokens.set(token, { userId: clientId, expiresAt: Date.now() + TOKEN_VALIDITY_MS });
+      latestTokens[clientId] = { token, time: newTime };
+      validTokens.set(token, {
+        userId: clientId,
+        expiresAt: Date.now() + TOKEN_VALIDITY_MS,
+      });
     }
 
     sendJSON(res, 200, {

--- a/test.js
+++ b/test.js
@@ -174,10 +174,9 @@ async function testObsoleteToken() {
 
   const oldToken = createToken({ id: 123, exp: now + 100 });
   res = await requestValidate(srv, oldToken);
-  assert.strictEqual(res.ok, false);
-  assert.strictEqual(res.reason, 'Token obsolète');
-  assert.strictEqual(_testing.revokedTokens.has(recentToken), false);
-  assert.strictEqual(_testing.validTokens.has(recentToken), true);
+  assert.strictEqual(res.ok, true);
+  assert.strictEqual(_testing.revokedTokens.has(recentToken), true);
+  assert.strictEqual(_testing.validTokens.has(recentToken), false);
 
   srv.close();
   setFetch(undefined);


### PR DESCRIPTION
## Summary
- simplify token replacement logic to always accept a newly validated token
- update tests to reflect acceptance of new tokens regardless of date

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6857debb4fe4832ca4b8c6ffb11c84dc