### PR TITLE
Add secure token management with link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Diploma Flashcard
+
+Cette application fournit un petit serveur de validation de tokens Exoatech.
+
+## Prérequis
+- Node.js \>= 18
+
+## Installation
+```bash
+npm install
+```
+
+## Lancement du serveur
+```bash
+npm start
+```
+Le serveur s'ex\u00e9cute par d\u00e9faut sur [http://localhost:3000](http://localhost:3000).
+
+## Tests
+```bash
+npm test
+```
+Tous les tests doivent afficher `All tests passed`.
+
+## Fonctionnement
+- `/validate?token=TOKEN` v\u00e9rifie un token Exoatech ou `/validate?link=LINKTOKEN` pour utiliser un lien temporaire.
+- `/generate-link?token=TOKEN` g\u00e9n\u00e8re un `linkToken` valable une heure.
+- Le serveur conserve uniquement le token le plus r\u00e9cent par utilisateur et r\u00e9voque les plus anciens.
+

--- a/revokedTokens.json
+++ b/revokedTokens.json
@@ -1,4 +1,1 @@
-[
-  "h.eyJpZCI6MTIzLCJleHAiOjE3NTA1Nzk4MjV9.s",
-  "h.eyJpZCI6MTIzLCJleHAiOjE3NTA1Nzk4NzV9.s"
-]
+[]


### PR DESCRIPTION
## Summary
- prevent older tokens from overriding newer ones
- clean revoked tokens, hash them on disk
- add `/generate-link` endpoint and link token validation
- hash tokens in localStorage and add session handling
- document usage and tests
- extend tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68581dce0608832cbf9956cee052f4e9