### PR TITLE
Add auto cleanup of revoked tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,6 @@ Tous les tests doivent afficher `All tests passed`.
 - `/validate?token=TOKEN` v\u00e9rifie un token Exoatech ou `/validate?link=LINKTOKEN` pour utiliser un lien temporaire.
 - `/generate-link?token=TOKEN` g\u00e9n\u00e8re un `linkToken` valable une heure.
 - Le serveur conserve uniquement le token le plus r\u00e9cent par utilisateur et r\u00e9voque les plus anciens.
+- Les tokens r\u00e9voqu\u00e9s sont conserv\u00e9s 30 jours et le fichier est nettoy\u00e9
+  automatiquement d\u00e8s qu'il d\u00e9passe 1000 entr\u00e9es.
 


### PR DESCRIPTION
## Summary
- limit stored revoked tokens to 1000 entries
- automatically enforce this limit during cleanup and token revocation
- document the behaviour in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859195e6fac832cb52efdfcc06a842d