### PR TITLE
Ensure SVGs invert in night mode

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2349,6 +2349,9 @@ body.dark-mode .flashcard-front {
 body.dark-mode .flashcard-front {
   box-shadow: inset 0 0 40px rgba(144, 202, 249, 0.15);
 }
+body.dark-mode .flashcard img[src$=".svg"] {
+  filter: brightness(0) invert(1);
+}
 /* Custom styling for subject icons */
 .features article .icon {
   background: linear-gradient(135deg, #6ec1e4, #00aeef);


### PR DESCRIPTION
## Summary
- tweak CSS so SVG images in flashcards invert when night mode is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859d7d3b724832c93ccf1de078510dd