### PR TITLE
Improve dark mode for chimie svg images

### DIFF
--- a/Chimie_Socle/chimie1.html
+++ b/Chimie_Socle/chimie1.html
@@ -311,6 +311,9 @@ function createContent(content) {
     img.alt = content.alt || "";
     img.style.maxWidth = "100%";
     img.style.height = "auto";
+    if (content.src && content.src.endsWith(".svg")) {
+      img.classList.add("svg-dark");
+    }
 
     wrapper.appendChild(img);
     return wrapper;

--- a/Chimie_Socle/chimie2.html
+++ b/Chimie_Socle/chimie2.html
@@ -310,6 +310,9 @@ function createContent(content) {
     img.style.maxHeight = "100%";
     img.style.height = "auto";
     img.style.objectFit = "contain";
+    if (content.src && content.src.endsWith(".svg")) {
+      img.classList.add("svg-dark");
+    }
 
     wrapper.appendChild(img);
     return wrapper;

--- a/Chimie_Socle/chimie3.html
+++ b/Chimie_Socle/chimie3.html
@@ -307,6 +307,9 @@ function createContent(content) {
     img.alt = content.alt || "";
     img.style.maxWidth = "100%";
     img.style.height = "auto";
+    if (content.src && content.src.endsWith(".svg")) {
+      img.classList.add("svg-dark");
+    }
 
     wrapper.appendChild(img);
     return wrapper;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2289,6 +2289,9 @@ button,
   height: 100% !important;
   object-fit: contain;
 }
+body.dark-mode .flashcard img.svg-dark {
+  filter: invert(1);
+}
 
 
 /* Dark mode overrides */


### PR DESCRIPTION
## Summary
- tweak dark mode css so SVGs on flashcards can invert
- update chimie1/2/3 flashcards to mark SVG images for dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859d99d8b20832c8ca4b62289779263