### PR TITLE
Fix dark mode flashcard icons

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2352,6 +2352,10 @@ body.dark-mode .flashcard-front {
 body.dark-mode .flashcard-front {
   box-shadow: inset 0 0 40px rgba(144, 202, 249, 0.15);
 }
+body.dark-mode .check-icon svg,
+body.dark-mode .cross-icon svg {
+  stroke: #ffffff !important;
+}
 /* Custom styling for subject icons */
 .features article .icon {
   background: linear-gradient(135deg, #6ec1e4, #00aeef);


### PR DESCRIPTION
## Summary
- ensure flashcard check/cross icons are white when using dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a8f3a7458832c8aa6dbdab9d1d58a