### PR TITLE
Add completion summary

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -328,3 +328,21 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 });
+
+// Add blue check icons in the menu for completed courses
+document.addEventListener('DOMContentLoaded', function() {
+  var links = document.querySelectorAll('#menu a[href$=".html"]');
+  links.forEach(function(link) {
+    var href = link.getAttribute('href');
+    if (!href) return;
+    var filename = href.split('/').pop().replace(/\.html$/, '');
+    var key = 'progress_' + filename;
+    if (localStorage.getItem(key) && !link.querySelector('.fa-check')) {
+      var icon = document.createElement('span');
+      icon.className = 'icon solid fa-check';
+      icon.style.color = '#00aeef';
+      icon.style.marginLeft = '0.25em';
+      link.appendChild(icon);
+    }
+  });
+});

--- a/index.html
+++ b/index.html
@@ -34,7 +34,8 @@
 											<h1>Diploma Santé<br /></h1>
 											<p>Plateforme de Flashcards</p>
 										</header>
-										<p>Boostez vos révisions en santé avec des flashcards efficaces, spécialement pensées pour les étudiants de l'USPN !</p>
+                                                                       <p>Boostez vos révisions en santé avec des flashcards efficaces, spécialement pensées pour les étudiants de l'USPN !</p>
+                                                                       <p id="courseSummary" style="color:#00aeef;"><span class="icon solid fa-star"></span> Cours complétés: <span id="completedCourses"></span>/<span id="totalCourses"></span></p>
 									</div>
 									<span class="image">
 										<img src="images/pic01.jpg" alt="" />
@@ -261,8 +262,16 @@
 			<script src="assets/js/browser.min.js"></script>
 			<script src="assets/js/breakpoints.min.js"></script>
 			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
-                        <script src="assets/js/darkmode.js"></script>
+                         <script src="assets/js/main.js"></script>
+                         <script src="assets/js/darkmode.js"></script>
+                         <script>
+                           document.addEventListener("DOMContentLoaded", function() {
+                             const completed = Object.keys(localStorage).filter(k => k.startsWith('progress_')).length;
+                             const total = 79;
+                             document.getElementById('completedCourses').textContent = completed;
+                             document.getElementById('totalCourses').textContent = total;
+                           });
+                         </script>
 
 	</body>
 </html>


### PR DESCRIPTION
## Summary
- show how many courses were completed in blue under the hero text
- compute completed courses from localStorage and show out of total courses
- mark completed courses with blue check icons in the menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b0c5fb478832c8caebbf56db900a5