### PR TITLE
Limit flashcard image size

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2285,9 +2285,12 @@ button,
 .flashcard { width: 95% !important; max-width: 900px !important; height: 450px !important; }
 .flashcard-front, .flashcard-back { font-size: 1.4rem !important; }
 .flashcard img {
-  width: 100% !important;
-  height: 100% !important;
+  width: auto !important;
+  height: auto !important;
+  max-width: 90% !important;
+  max-height: 90% !important;
   object-fit: contain;
+  margin: auto;
 }
 body.dark-mode .flashcard img.svg-dark {
   filter: invert(1);


### PR DESCRIPTION
## Summary
- prevent images from exceeding flashcard container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b13e22ef4832cb0271201e3584821