### PR TITLE
Fix oversized images in flashcards

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2291,7 +2291,7 @@ button,
   width: auto !important;
   height: auto !important;
   max-width: 90% !important;
-  max-height: 90% !important;
+  max-height: min(90%, 300px) !important;
   object-fit: contain;
   margin: auto;
 }


### PR DESCRIPTION
## Summary
- keep images inside flashcards from exceeding the container by capping their height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bcfa1cb98832c8ecaed95e782a244