### PR TITLE
Add favorites menu link and fix script order

### DIFF
--- a/Anatomie_App/anatapp1.html
+++ b/Anatomie_App/anatapp1.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -454,7 +455,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -465,6 +479,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -508,6 +523,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp10.html
+++ b/Anatomie_App/anatapp10.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 <div id="wrapper">
@@ -127,7 +128,21 @@ let currentIndex = parseInt(localStorage.getItem(progressKey)) || 0;
 function updateProgress(){const total=originalData.length;const progress=Math.min(currentIndex/total,1);progressBar.style.width=`${progress*100}%`;}
 function createContent(content){if(typeof content==="string"){const div=document.createElement("div");div.textContent=content;return div;}if(typeof content==="object"&&content.type==="image"){const wrapper=document.createElement("div");wrapper.style.textAlign="center";if(content.caption){const caption=document.createElement("div");caption.textContent=content.caption;caption.style.marginBottom="6px";caption.style.fontStyle="italic";caption.style.fontSize="0.9em";wrapper.appendChild(caption);}const img=document.createElement("img");img.src=content.src;img.alt=content.alt||"";img.style.maxWidth="100%";img.style.height="auto";wrapper.appendChild(img);return wrapper;}return document.createElement("div");}
 function showCard(index){container.innerHTML="";if(flashcards[index]){const{question,answer}=flashcards[index];const card=document.createElement("div");card.classList.add("flashcard","show");const inner=document.createElement("div");inner.classList.add("flashcard-inner");const front=document.createElement("div");front.classList.add("flashcard-front");front.appendChild(createContent(question));const back=document.createElement("div");back.classList.add("flashcard-back");back.appendChild(createContent(answer));const btnContainer=document.createElement("div");btnContainer.classList.add("flashcard-button");const toggleBtn=document.createElement("button");toggleBtn.classList.add("button","large");toggleBtn.textContent="Voir la réponse";btnContainer.appendChild(toggleBtn);const checkIcon=document.createElement("span");checkIcon.classList.add("check-icon");checkIcon.innerHTML=`<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' stroke='#888' stroke-width='3' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 24 24'><polyline points='20 6 9 17 4 12'/></svg>`;checkIcon.addEventListener("click",e=>{e.stopPropagation();card.classList.add("slide-right");setTimeout(()=>{currentIndex++;
-        localStorage.setItem(progressKey, currentIndex);updateProgress();showCard(currentIndex);},400);});const crossIcon=document.createElement("span");crossIcon.classList.add("cross-icon");crossIcon.innerHTML=`<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' stroke='#888' stroke-width='3' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 24 24'><line x1='18' y1='6' x2='6' y2='18'/><line x1='6' y1='6' x2='18' y2='18'/></svg>`;crossIcon.addEventListener("click",e=>{e.stopPropagation();card.classList.add("slide-left");setTimeout(()=>{const removed=flashcards.splice(currentIndex,1)[0];flashcards.splice(currentIndex+5,0,removed);showCard(currentIndex);},400);});card.addEventListener("click",()=>{const isAnswerVisible=card.classList.toggle("show-answer");toggleBtn.textContent=isAnswerVisible?"Cacher la réponse":"Voir la réponse";});inner.appendChild(front);inner.appendChild(back);card.appendChild(inner);card.appendChild(btnContainer);card.appendChild(checkIcon);card.appendChild(crossIcon);container.appendChild(card);}else{container.innerHTML="<p>Plus de flashcards disponibles.</p>";updateProgress();}}
+        localStorage.setItem(progressKey, currentIndex);updateProgress();showCard(currentIndex);},400);});const crossIcon=document.createElement("span");crossIcon.classList.add("cross-icon");crossIcon.innerHTML=`<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' stroke='#888' stroke-width='3' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 24 24'><line x1='18' y1='6' x2='6' y2='18'/><line x1='6' y1='6' x2='18' y2='18'/></svg>`;crossIcon.addEventListener("click",e=>{e.stopPropagation();card.classList.add("slide-left");setTimeout(()=>{const removed=flashcards.splice(currentIndex,1)[0];flashcards.splice(currentIndex+5,0,removed);showCard(currentIndex);},400);});    const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click",()=>{const isAnswerVisible=card.classList.toggle("show-answer");toggleBtn.textContent=isAnswerVisible?"Cacher la réponse":"Voir la réponse";});inner.appendChild(front);inner.appendChild(back);card.appendChild(inner);card.appendChild(btnContainer);card.appendChild(checkIcon);card.appendChild(crossIcon);
+    card.appendChild(favIcon);container.appendChild(card);}else{container.innerHTML="<p>Plus de flashcards disponibles.</p>";updateProgress();}}
     localStorage.setItem("completed_" + pageId, "true");
 document.getElementById("reset").addEventListener("click",()=>{
   localStorage.removeItem(progressKey);flashcards=[...originalData];currentIndex=0;updateProgress();showCard(currentIndex);});
@@ -148,6 +163,7 @@ showCard(currentIndex);updateProgress();
 <header class="major"><h2>Menu</h2></header>
 <ul>
 <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
 <li><span class="opener">Biochimie Socle</span>
 <ul>
 <li><a href="../Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>

--- a/Anatomie_App/anatapp11.html
+++ b/Anatomie_App/anatapp11.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -423,7 +424,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -434,6 +448,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -484,6 +499,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp12.html
+++ b/Anatomie_App/anatapp12.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -429,7 +430,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -440,6 +454,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -490,6 +505,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp13.html
+++ b/Anatomie_App/anatapp13.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -441,7 +442,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -452,6 +466,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -502,6 +517,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp2.html
+++ b/Anatomie_App/anatapp2.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -726,7 +727,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -737,6 +751,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -779,6 +794,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp3.html
+++ b/Anatomie_App/anatapp3.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -429,7 +430,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -440,6 +454,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -483,6 +498,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp4.html
+++ b/Anatomie_App/anatapp4.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -439,7 +440,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -450,6 +464,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -500,6 +515,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp5.html
+++ b/Anatomie_App/anatapp5.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -420,7 +421,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -431,6 +445,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -481,6 +496,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp6.html
+++ b/Anatomie_App/anatapp6.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -463,7 +464,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -474,6 +488,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -524,6 +539,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp7.html
+++ b/Anatomie_App/anatapp7.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -424,7 +425,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -435,6 +449,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -485,6 +500,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_App/anatapp8.html
+++ b/Anatomie_App/anatapp8.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 <div id="wrapper">
@@ -127,7 +128,21 @@ let currentIndex = parseInt(localStorage.getItem(progressKey)) || 0;
 function updateProgress(){ const total = originalData.length; const progress = Math.min(currentIndex/total,1); progressBar.style.width = `${progress*100}%`; }
 function createContent(content){ if(typeof content === "string"){ const div=document.createElement("div"); div.textContent=content; return div; } if(typeof content === "object" && content.type === "image"){ const wrapper=document.createElement("div"); wrapper.style.textAlign="center"; if(content.caption){ const caption=document.createElement("div"); caption.textContent=content.caption; caption.style.marginBottom="6px"; caption.style.fontStyle="italic"; caption.style.fontSize="0.9em"; wrapper.appendChild(caption);} const img=document.createElement("img"); img.src=content.src; img.alt=content.alt||""; img.style.maxWidth="100%"; img.style.height="auto"; wrapper.appendChild(img); return wrapper;} return document.createElement("div"); }
 function showCard(index){ container.innerHTML=""; if(flashcards[index]){ const {question,answer}=flashcards[index]; const card=document.createElement("div"); card.classList.add("flashcard","show"); const inner=document.createElement("div"); inner.classList.add("flashcard-inner"); const front=document.createElement("div"); front.classList.add("flashcard-front"); front.appendChild(createContent(question)); const back=document.createElement("div"); back.classList.add("flashcard-back"); back.appendChild(createContent(answer)); const btnContainer=document.createElement("div"); btnContainer.classList.add("flashcard-button"); const toggleBtn=document.createElement("button"); toggleBtn.classList.add("button","large"); toggleBtn.textContent="Voir la réponse"; btnContainer.appendChild(toggleBtn); const checkIcon=document.createElement("span"); checkIcon.classList.add("check-icon"); checkIcon.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="#888" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12" /></svg>`; checkIcon.addEventListener("click",(e)=>{ e.stopPropagation(); card.classList.add("slide-right"); setTimeout(()=>{ currentIndex++;
-        localStorage.setItem(progressKey, currentIndex); updateProgress(); showCard(currentIndex); },400);}); const crossIcon=document.createElement("span"); crossIcon.classList.add("cross-icon"); crossIcon.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="#888" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>`; crossIcon.addEventListener("click",(e)=>{ e.stopPropagation(); card.classList.add("slide-left"); setTimeout(()=>{ const removed=flashcards.splice(currentIndex,1)[0]; flashcards.splice(currentIndex+5,0,removed); showCard(currentIndex); },400);}); card.addEventListener("click",()=>{ const isAnswerVisible=card.classList.toggle("show-answer"); toggleBtn.textContent=isAnswerVisible?"Cacher la réponse":"Voir la réponse"; }); inner.appendChild(front); inner.appendChild(back); card.appendChild(inner); card.appendChild(btnContainer); card.appendChild(checkIcon); card.appendChild(crossIcon); container.appendChild(card);} else { container.innerHTML="<p>Plus de flashcards disponibles.</p>"; updateProgress(); } }
+        localStorage.setItem(progressKey, currentIndex); updateProgress(); showCard(currentIndex); },400);}); const crossIcon=document.createElement("span"); crossIcon.classList.add("cross-icon"); crossIcon.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="#888" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>`; crossIcon.addEventListener("click",(e)=>{ e.stopPropagation(); card.classList.add("slide-left"); setTimeout(()=>{ const removed=flashcards.splice(currentIndex,1)[0]; flashcards.splice(currentIndex+5,0,removed); showCard(currentIndex); },400);});     const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click",()=>{ const isAnswerVisible=card.classList.toggle("show-answer"); toggleBtn.textContent=isAnswerVisible?"Cacher la réponse":"Voir la réponse"; }); inner.appendChild(front); inner.appendChild(back); card.appendChild(inner); card.appendChild(btnContainer); card.appendChild(checkIcon); card.appendChild(crossIcon);
+    card.appendChild(favIcon); container.appendChild(card);} else { container.innerHTML="<p>Plus de flashcards disponibles.</p>"; updateProgress(); } }
     localStorage.setItem("completed_" + pageId, "true");
 document.getElementById("reset").addEventListener("click",()=>{
   localStorage.removeItem(progressKey); flashcards=[...originalData]; currentIndex=0; updateProgress(); showCard(currentIndex);});
@@ -148,6 +163,7 @@ showCard(currentIndex); updateProgress();
 <header class="major"><h2>Menu</h2></header>
 <ul>
 <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
 <li><span class="opener">Biochimie Socle</span>
 <ul>
 <li><a href="Biochimie_Socle/bioch1.html">Structure et propriétés des acides aminés</a></li>

--- a/Anatomie_App/anatapp9.html
+++ b/Anatomie_App/anatapp9.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 <!-- Wrapper -->
@@ -327,7 +328,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -338,6 +352,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -377,6 +392,7 @@ updateProgress();
 </header>
 <ul>
 <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
 <li>
 <span class="opener">Biochimie Socle</span>
 <ul>

--- a/Anatomie_Socle/anat1.html
+++ b/Anatomie_Socle/anat1.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -436,7 +437,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -447,6 +461,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -497,6 +512,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat10.html
+++ b/Anatomie_Socle/anat10.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -360,7 +361,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -371,6 +385,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -421,6 +436,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat11.html
+++ b/Anatomie_Socle/anat11.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -411,7 +412,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -422,6 +436,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -472,6 +487,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat12.html
+++ b/Anatomie_Socle/anat12.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -438,7 +439,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -449,6 +463,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -499,6 +514,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat2.html
+++ b/Anatomie_Socle/anat2.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -446,7 +447,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -457,6 +471,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -507,6 +522,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat3.html
+++ b/Anatomie_Socle/anat3.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -466,7 +467,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -477,6 +491,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -527,6 +542,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat4.html
+++ b/Anatomie_Socle/anat4.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -436,7 +437,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -447,6 +461,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -497,6 +512,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat5.html
+++ b/Anatomie_Socle/anat5.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -408,7 +409,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -419,6 +433,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -469,6 +484,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat6.html
+++ b/Anatomie_Socle/anat6.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -424,7 +425,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -435,6 +449,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -485,6 +500,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat7.html
+++ b/Anatomie_Socle/anat7.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -367,7 +368,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -378,6 +392,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -428,6 +443,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat8.html
+++ b/Anatomie_Socle/anat8.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -471,7 +472,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -482,6 +496,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -532,6 +547,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Anatomie_Socle/anat9.html
+++ b/Anatomie_Socle/anat9.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -414,7 +415,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -425,6 +439,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -475,6 +490,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_App/biochapp1.html
+++ b/Biochimie_App/biochapp1.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -389,7 +390,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -400,6 +414,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -443,6 +458,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_App/biochapp2.html
+++ b/Biochimie_App/biochapp2.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -366,7 +367,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -377,6 +391,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -420,6 +435,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_App/biochapp4.html
+++ b/Biochimie_App/biochapp4.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -379,7 +380,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -390,6 +404,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -433,6 +448,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_App/biochapp5.html
+++ b/Biochimie_App/biochapp5.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -396,7 +397,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -407,6 +421,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -449,6 +464,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_App/biochapp6.html
+++ b/Biochimie_App/biochapp6.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -450,7 +451,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -461,6 +475,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -505,6 +520,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_App/biochapp7.html
+++ b/Biochimie_App/biochapp7.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -405,7 +406,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -416,6 +430,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -459,6 +474,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch1.html
+++ b/Biochimie_Socle/bioch1.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -446,7 +447,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -457,6 +471,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -503,6 +518,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch10.html
+++ b/Biochimie_Socle/bioch10.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -354,7 +355,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -365,6 +379,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -408,6 +423,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch11.html
+++ b/Biochimie_Socle/bioch11.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -398,7 +399,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -409,6 +423,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -452,6 +467,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch12.html
+++ b/Biochimie_Socle/bioch12.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -352,7 +353,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -363,6 +377,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -406,6 +421,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch13.html
+++ b/Biochimie_Socle/bioch13.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -405,7 +406,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -416,6 +430,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -459,6 +474,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch14.html
+++ b/Biochimie_Socle/bioch14.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -472,7 +473,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -483,6 +497,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -526,6 +541,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch15.html
+++ b/Biochimie_Socle/bioch15.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -478,7 +479,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -489,6 +503,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -532,6 +547,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch2.html
+++ b/Biochimie_Socle/bioch2.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -438,7 +439,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -449,6 +463,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -492,6 +507,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch3.html
+++ b/Biochimie_Socle/bioch3.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -436,7 +437,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -447,6 +461,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -490,6 +505,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch4.html
+++ b/Biochimie_Socle/bioch4.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -433,7 +434,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -444,6 +458,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -487,6 +502,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch5.html
+++ b/Biochimie_Socle/bioch5.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -402,7 +403,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -413,6 +427,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -456,6 +471,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch6.html
+++ b/Biochimie_Socle/bioch6.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -386,7 +387,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -397,6 +411,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -439,6 +454,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch7.html
+++ b/Biochimie_Socle/bioch7.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -411,7 +412,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -422,6 +436,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -465,6 +480,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch8.html
+++ b/Biochimie_Socle/bioch8.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -399,7 +400,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -410,6 +424,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -453,6 +468,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biochimie_Socle/bioch9.html
+++ b/Biochimie_Socle/bioch9.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -440,7 +441,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -451,6 +465,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -494,6 +509,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell1.html
+++ b/Biologie_Cellulaire/biocell1.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -381,7 +382,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -392,6 +406,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -442,6 +457,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell10.html
+++ b/Biologie_Cellulaire/biocell10.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -396,7 +397,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -407,6 +421,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -454,6 +469,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell11.html
+++ b/Biologie_Cellulaire/biocell11.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -606,7 +607,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -617,6 +631,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -664,6 +679,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell13.html
+++ b/Biologie_Cellulaire/biocell13.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -544,7 +545,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -555,6 +569,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -602,6 +617,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell14.html
+++ b/Biologie_Cellulaire/biocell14.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -549,7 +550,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -560,6 +574,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -607,6 +622,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell15.html
+++ b/Biologie_Cellulaire/biocell15.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -519,7 +520,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -530,6 +544,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -577,6 +592,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell16.html
+++ b/Biologie_Cellulaire/biocell16.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -470,7 +471,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -481,6 +495,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -528,6 +543,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell17.html
+++ b/Biologie_Cellulaire/biocell17.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -438,7 +439,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -449,6 +463,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -496,6 +511,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell18.html
+++ b/Biologie_Cellulaire/biocell18.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -481,7 +482,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -492,6 +506,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -539,6 +554,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell2.html
+++ b/Biologie_Cellulaire/biocell2.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -501,7 +502,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -512,6 +526,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -557,6 +572,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell3.html
+++ b/Biologie_Cellulaire/biocell3.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -465,7 +466,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -476,6 +490,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -521,6 +536,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell4.html
+++ b/Biologie_Cellulaire/biocell4.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -482,7 +483,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -493,6 +507,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -539,6 +554,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell5.html
+++ b/Biologie_Cellulaire/biocell5.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -429,7 +430,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -440,6 +454,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -485,6 +500,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell7.html
+++ b/Biologie_Cellulaire/biocell7.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -514,7 +515,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -525,6 +539,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -572,6 +587,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell8.html
+++ b/Biologie_Cellulaire/biocell8.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -472,7 +473,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -483,6 +497,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -530,6 +545,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Biologie_Cellulaire/biocell9.html
+++ b/Biologie_Cellulaire/biocell9.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -431,7 +432,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -442,6 +456,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -489,6 +504,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Chimie_App/chimieapp1.html
+++ b/Chimie_App/chimieapp1.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -347,7 +348,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -358,6 +372,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -404,6 +419,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Chimie App</span>
                       <ul>

--- a/Chimie_App/chimieapp2.html
+++ b/Chimie_App/chimieapp2.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -351,7 +352,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -362,6 +376,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -408,6 +423,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Chimie App</span>
                       <ul>

--- a/Chimie_App/chimieapp3.html
+++ b/Chimie_App/chimieapp3.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -349,7 +350,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -360,6 +374,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -406,6 +421,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Chimie App</span>
                       <ul>

--- a/Chimie_Socle/chimie1.html
+++ b/Chimie_Socle/chimie1.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -388,7 +389,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -399,6 +413,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -445,6 +460,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Chimie_Socle/chimie2.html
+++ b/Chimie_Socle/chimie2.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -387,7 +388,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -398,6 +412,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -444,6 +459,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Chimie_Socle/chimie3.html
+++ b/Chimie_Socle/chimie3.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -384,7 +385,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -395,6 +409,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -441,6 +456,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Chimie_Socle/chimie4.html
+++ b/Chimie_Socle/chimie4.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -385,7 +386,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -396,6 +410,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -442,6 +457,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Chimie_Socle/chimie5.html
+++ b/Chimie_Socle/chimie5.html
@@ -7,7 +7,8 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
             <script src="../security.js" defer></script>
-        </head>
+            <script src="../assets/js/favorites.js"></script>
+</head>
         <body class="is-preload">
 
                 <!-- Wrapper -->
@@ -388,7 +389,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -399,6 +413,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -445,6 +460,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Chimie_Socle/chimie6.html
+++ b/Chimie_Socle/chimie6.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -375,7 +376,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -386,6 +400,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -432,6 +447,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Chimie_Socle/chimie7.html
+++ b/Chimie_Socle/chimie7.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -407,7 +408,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -418,6 +432,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -464,6 +479,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Chimie_Socle/chimie8.html
+++ b/Chimie_Socle/chimie8.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -348,7 +349,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -359,6 +373,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -405,6 +420,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/Chimie_Socle/chimie9.html
+++ b/Chimie_Socle/chimie9.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
 	    <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 	<body class="is-preload">
 
@@ -376,7 +377,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -387,6 +401,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -433,6 +448,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/SHS_Socle/shs1.html
+++ b/SHS_Socle/shs1.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -414,7 +415,33 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+    const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -425,6 +452,8 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -475,6 +504,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/SHS_Socle/shs2.html
+++ b/SHS_Socle/shs2.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -370,7 +371,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -381,6 +395,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -431,6 +446,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="../index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/SHS_Socle/shs3.html
+++ b/SHS_Socle/shs3.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -484,7 +485,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -495,6 +509,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -545,6 +560,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/SHS_Socle/shs4.html
+++ b/SHS_Socle/shs4.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -394,7 +395,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -405,6 +419,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -455,6 +470,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/SHS_Socle/shs5.html
+++ b/SHS_Socle/shs5.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../assets/css/main.css" />
 <link rel="icon" type="image/jpeg" href="../images/diploma.jpeg" />
     <script src="../security.js" defer></script>
+    <script src="../assets/js/favorites.js"></script>
 </head>
 <body class="is-preload">
 
@@ -382,7 +383,20 @@ function showCard(index) {
       }, 400);
     });
 
-    card.addEventListener("click", () => {
+        const favIcon = document.createElement("span");
+    favIcon.classList.add("favorite-icon");
+    favIcon.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>`;
+    function updateFav() {
+      if (isFavorite({question, answer})) favIcon.classList.add("active");
+      else favIcon.classList.remove("active");
+    }
+    favIcon.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleFavorite({question, answer});
+      updateFav();
+    });
+    updateFav();
+card.addEventListener("click", () => {
       const isAnswerVisible = card.classList.toggle("show-answer");
       toggleBtn.textContent = isAnswerVisible ? "Cacher la réponse" : "Voir la réponse";
     });
@@ -393,6 +407,7 @@ function showCard(index) {
     card.appendChild(btnContainer);
     card.appendChild(checkIcon);
     card.appendChild(crossIcon);
+    card.appendChild(favIcon);
 
     container.appendChild(card);
   } else {
@@ -443,6 +458,7 @@ updateProgress();
                   </header>
                   <ul>
                     <li><a href="index.html">Accueil</a></li>
+                    <li><a href="../favorites.html">Favoris</a></li>
                     <li>
                       <span class="opener">Biochimie Socle</span>
                       <ul>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2362,6 +2362,10 @@ body.dark-mode .check-icon svg,
 body.dark-mode .cross-icon svg {
   stroke: #ffffff !important;
 }
+.favorite-icon { display:none; position:absolute; bottom:10px; right:10px; font-size:1.8rem; cursor:pointer; z-index:10; color:#f1c40f; }
+.flashcard.show-answer .favorite-icon { display:block; }
+.favorite-icon.active { color:#f39c12; }
+body.dark-mode .favorite-icon { color:#f7d060; }
 /* Custom styling for subject icons */
 .features article .icon {
   background: linear-gradient(135deg, #6ec1e4, #00aeef);

--- a/assets/js/favorites.js
+++ b/assets/js/favorites.js
@@ -1,0 +1,41 @@
+function getFavorites() {
+  try {
+    return JSON.parse(localStorage.getItem('favorites') || '[]');
+  } catch (e) {
+    return [];
+  }
+}
+
+function saveFavorites(favs) {
+  localStorage.setItem('favorites', JSON.stringify(favs));
+}
+
+function isSameCard(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function isFavorite(card) {
+  return getFavorites().some(f => isSameCard(f, card));
+}
+
+function addFavorite(card) {
+  const favs = getFavorites();
+  if (!favs.some(f => isSameCard(f, card))) {
+    favs.push(card);
+    saveFavorites(favs);
+  }
+}
+
+function removeFavorite(card) {
+  let favs = getFavorites();
+  favs = favs.filter(f => !isSameCard(f, card));
+  saveFavorites(favs);
+}
+
+function toggleFavorite(card) {
+  if (isFavorite(card)) removeFavorite(card); else addFavorite(card);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { getFavorites, saveFavorites, isFavorite, addFavorite, removeFavorite, toggleFavorite };
+}

--- a/favorites.html
+++ b/favorites.html
@@ -1,110 +1,42 @@
 <!DOCTYPE HTML>
 <html>
-	<head>
-		<title>Diploma Santé - Plateforme de Flashcards</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
-<link rel="icon" type="image/jpeg" href="images/diploma.jpeg" />
-	    <script src="security.js" defer></script>
+<head>
+  <title>Diploma Santé - Favoris</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+  <link rel="icon" type="image/jpeg" href="images/diploma.jpeg" />
+  <script src="security.js" defer></script>
+    <script src="assets/js/favorites.js"></script>
 </head>
-       <body class="is-preload index-page">
+<body class="is-preload">
+  <div id="wrapper">
+    <div id="main">
+      <div class="inner">
+        <header id="header">
+          <a href="index.html" class="logo"><strong>Diploma Santé</strong>- Plateforme de Flashcards</a>
+          <ul class="icons">
+            <li><a href="https://diploma-sante.fr/" class="icon fas fa-globe"><span class="label"></span></a></li>
+            <li><a href="https://www.instagram.com/diplomasante/" class="icon brands fa-instagram"><span class="label">Instagram</span></a></li>
+            <li><a href="#" id="dark-mode-toggle" class="icon fas fa-moon"></a></li>
+          </ul>
+        </header>
 
-		<!-- Wrapper -->
-			<div id="wrapper">
+        <section>
+          <header class="main">
+            <h1>Flashcards favorites</h1>
+          </header>
 
-				<!-- Main -->
-					<div id="main">
-						<div class="inner">
-
-							<!-- Header -->
-								<header id="header">
-									<a href="index.html" class="logo"><strong>Diploma Santé</strong>- Plateforme de Flashcards</a>
-									<ul class="icons">
-										<li><a href="https://diploma-sante.fr/" class="icon fas fa-globe"><span class="label"></span></a></li>
-										<li><a href="https://www.instagram.com/diplomasante/" class="icon brands fa-instagram"><span class="label">Instagram</span></a></li>
-                        <li><a href="#" id="dark-mode-toggle" class="icon fas fa-moon"></a></li>
-									</ul>
-								</header>
-
-							<!-- Banner -->
-								<section id="banner">
-									<div class="content">
-										<header>
-											<h1>Diploma Santé<br /></h1>
-											<p>Plateforme de Flashcards</p>
-										</header>
-                                                                       <p>Boostez vos révisions en santé avec des flashcards efficaces, spécialement pensées pour les étudiants de l'USPN !</p>
-                                                                       <p id="courseSummary" style="color:#00aeef;"><span class="icon solid fa-star"></span> Cours complétés: <strong><span id="completedCourses"></span>/<span id="totalCourses"></span></strong></p>
-									</div>
-									<span class="image">
-										<img src="images/pic01.jpg" alt="" />
-									</span>
-								</section>
-
-							<!-- Section -->
-								<section>
-									<header class="major">
-										<h2>Explorez les matières disponibles</h2>
-									</header>
-									<div class="features">
-										<article>
-                                                                               <span class="icon solid fa-flask"></span>
-											<div class="content">
-												<h3>Biochimie</h3>
-												<ul class="actions">
-													<li><a href="Biochimie_Socle/bioch1.html" class="button big">Commencer</a></li>
-												</ul>
-											</div>
-										</article>
-										<article>
-                                                                               <span class="icon solid fa-dna"></span>
-											<div class="content">
-												<h3>Biologie cellulaire</h3>
-												<ul class="actions">
-													<li><a href="Biologie_Cellulaire/biocell1.html" class="button big">Commencer</a></li>
-												</ul>
-											</div>
-										</article>
-										<article>
-                                                                               <span class="icon solid fa-book-open"></span>
-											<div class="content">
-												<h3>Sciences humaines et sociales</h3>
-												<ul class="actions">
-													<li><a href="SHS_Socle/shs1.html" class="button big">Commencer</a></li>
-												</ul>
-											</div>
-										</article>
-										<article>
-                                                                               <span class="icon solid fa-user-md"></span>
-											<div class="content">
-												<h3>Anatomie</h3>
-												<ul class="actions">
-													<li><a href="Anatomie_Socle/anat1.html" class="button big">Commencer</a></li>
-												</ul>
-											</div>
-										</article>
-										<article>
-											<span class="icon solid fa-atom"></span>
-											<div class="content">
-												<h3>Chimie</h3>
-												<ul class="actions">
-													<li><a href="Chimie_Socle/chimie1.html" class="button big">Commencer</a></li>
-												</ul>
-											</div>
-										</article>
-									</div>
-								</section>
-
-											
-						</div>
-					</div>
-
-				<!-- Sidebar -->
-					<div id="sidebar">
-						<div class="inner">
-
-							<!-- Menu -->
+          <div class="progress-container">
+            <div class="progress-bar" id="progressBar"></div>
+          </div>
+          <div class="flashcards-container" id="flashcards"></div>
+          <p style="text-align:center"><button id="reset" class="button small">Réinitialiser</button></p>
+        </section>
+      </div>
+    </div>
+    <div id="sidebar">
+      <div class="inner">
 <section id="search" class="alt">
 <form method="post" action="#">
 <input type="text" name="query" id="query" placeholder="Rechercher">
@@ -252,28 +184,140 @@
 								<footer id="footer">
 									<p class="copyright">&copy; Diploma Santé. Tous droits réservés.</p>
 								</footer>
+    </div>
+  </div>
 
-						</div>
-					</div>
+  <script src="assets/js/jquery.min.js"></script>
+  <script src="assets/js/browser.min.js"></script>
+  <script src="assets/js/breakpoints.min.js"></script>
+  <script src="assets/js/util.js"></script>
+  <script src="assets/js/main.js"></script>
+  <script src="assets/js/darkmode.js"></script>
+<script>
+    const flashcardsData = getFavorites();
+    const container = document.getElementById('flashcards');
+    const progressBar = document.getElementById('progressBar');
+    const originalData = [...flashcardsData];
+    let flashcards = [...originalData];
+    let currentIndex = 0;
 
-			</div>
+    function updateProgress() {
+      const total = originalData.length;
+      const progress = Math.min(currentIndex / total, 1);
+      progressBar.style.width = `${progress * 100}%`;
+    }
 
-		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-                         <script src="assets/js/main.js"></script>
-                         <script src="assets/js/darkmode.js"></script>
-<script src="assets/js/favorites.js"></script>
-                         <script>
-                           document.addEventListener("DOMContentLoaded", function() {
-                             const completed = Object.keys(localStorage).filter(k => k.startsWith('completed_')).length;
-                             const total = 79;
-                             document.getElementById('completedCourses').textContent = completed;
-                             document.getElementById('totalCourses').textContent = total;
-                           });
-                         </script>
+    function createContent(content) {
+      if (typeof content === 'string') {
+        const div = document.createElement('div');
+        div.textContent = content;
+        return div;
+      }
+      if (typeof content === 'object' && content.type === 'image') {
+        const wrapper = document.createElement('div');
+        wrapper.style.textAlign = 'center';
+        if (content.caption) {
+          const caption = document.createElement('div');
+          caption.textContent = content.caption;
+          caption.style.marginBottom = '6px';
+          caption.style.fontStyle = 'italic';
+          caption.style.fontSize = '0.9em';
+          wrapper.appendChild(caption);
+        }
+        const img = document.createElement('img');
+        img.src = content.src;
+        img.alt = content.alt || '';
+        img.style.maxWidth = '100%';
+        img.style.height = 'auto';
+        wrapper.appendChild(img);
+        return wrapper;
+      }
+      return document.createElement('div');
+    }
 
-	</body>
+    function showCard(index) {
+      container.innerHTML = '';
+      if (flashcards[index]) {
+        const { question, answer } = flashcards[index];
+        const card = document.createElement('div');
+        card.classList.add('flashcard', 'show');
+        const inner = document.createElement('div');
+        inner.classList.add('flashcard-inner');
+        const front = document.createElement('div');
+        front.classList.add('flashcard-front');
+        front.appendChild(createContent(question));
+        const back = document.createElement('div');
+        back.classList.add('flashcard-back');
+        back.appendChild(createContent(answer));
+        const btnContainer = document.createElement('div');
+        btnContainer.classList.add('flashcard-button');
+        const toggleBtn = document.createElement('button');
+        toggleBtn.classList.add('button', 'large');
+        toggleBtn.textContent = 'Voir la réponse';
+        btnContainer.appendChild(toggleBtn);
+        const checkIcon = document.createElement('span');
+        checkIcon.classList.add('check-icon');
+        checkIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="#888" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12" /></svg>';
+        checkIcon.addEventListener('click', (e) => {
+          e.stopPropagation();
+          card.classList.add('slide-right');
+          setTimeout(() => {
+            currentIndex++;
+            updateProgress();
+            showCard(currentIndex);
+          }, 400);
+        });
+        const crossIcon = document.createElement('span');
+        crossIcon.classList.add('cross-icon');
+        crossIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="#888" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>';
+        crossIcon.addEventListener('click', (e) => {
+          e.stopPropagation();
+          card.classList.add('slide-left');
+          setTimeout(() => {
+            const removed = flashcards.splice(currentIndex, 1)[0];
+            flashcards.splice(currentIndex + 5, 0, removed);
+            showCard(currentIndex);
+          }, 400);
+        });
+        const favIcon = document.createElement('span');
+        favIcon.classList.add('favorite-icon');
+        favIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M8 .25l1.938 3.92L14 4.75l-3 2.93L11.875 12 8 10l-3.875 2 1.875-4.32-3-2.93 4.062-.58L8 .25z"/></svg>';
+        function updateFav() {
+          if (isFavorite({question, answer})) favIcon.classList.add('active');
+          else favIcon.classList.remove('active');
+        }
+        favIcon.addEventListener('click', (e) => {
+          e.stopPropagation();
+          toggleFavorite({question, answer});
+          updateFav();
+        });
+        updateFav();
+        card.addEventListener('click', () => {
+          const isAnswerVisible = card.classList.toggle('show-answer');
+          toggleBtn.textContent = isAnswerVisible ? 'Cacher la réponse' : 'Voir la réponse';
+        });
+        inner.appendChild(front);
+        inner.appendChild(back);
+        card.appendChild(inner);
+        card.appendChild(btnContainer);
+        card.appendChild(checkIcon);
+        card.appendChild(crossIcon);
+        card.appendChild(favIcon);
+        container.appendChild(card);
+      } else {
+        container.innerHTML = '<p>Plus de flashcards disponibles.</p>';
+      }
+    }
+
+    document.getElementById('reset').addEventListener('click', () => {
+      flashcards = [...originalData];
+      currentIndex = 0;
+      updateProgress();
+      showCard(currentIndex);
+    });
+
+    showCard(currentIndex);
+    updateProgress();
+  </script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- load favorites helper before inline scripts
- link to favourites page from every sidebar menu
- repair favorites page menu and script setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bcf7b0730832cb33da02702b280a8