### PR TITLE
Add PM2 config and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,21 @@ Tous les tests doivent afficher `All tests passed`.
 - Les tokens r\u00e9voqu\u00e9s sont conserv\u00e9s 30 jours et le fichier est nettoy\u00e9
   automatiquement d\u00e8s qu'il d\u00e9passe 1000 entr\u00e9es.
 
+## D\u00e9ploiement avec PM2 sur Debian 12
+Pour un environnement de production sur un VPS (ex. Hetzner) utilisant Debian\u00a012, vous pouvez g\u00e9rer le processus avec [PM2](https://pm2.keymetrics.io/).
+
+1. Installer PM2 globalement\u00a0:
+   ```bash
+   npm install -g pm2
+   ```
+2. D\u00e9marrer l'application avec la configuration fournie\u00a0:
+   ```bash
+   pm2 start ecosystem.config.js
+   ```
+3. Configurer PM2 pour red\u00e9marrer le service au d\u00e9marrage du serveur\u00a0:
+   ```bash
+   pm2 startup systemd
+   pm2 save
+   ```
+PM2 utilisera le fichier `ecosystem.config.js` pour lancer `server.js` sur le port\u00a03000 et red\u00e9marrera automatiquement le processus en cas de crash ou de red\u00e9marrage du serveur.
+

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  apps: [
+    {
+      name: 'diploma-server',
+      script: './server.js',
+      env: {
+        PORT: 3000
+      },
+      autorestart: true,
+      watch: false
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "test": "node test.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "start:pm2": "pm2 start ecosystem.config.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add PM2 ecosystem file to run server on port 3000
- document PM2 deployment steps for Debian 12
- expose `start:pm2` helper script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689372b20bf8832c873ccac50d1a8e63