### PR TITLE
Handle creatorUserId tokens

### DIFF
--- a/security.js
+++ b/security.js
@@ -49,7 +49,7 @@ async function verifierToken() {
     window.location.href = "unauthorized.html";
     return;
   }
-  const clientId = decoded ? (decoded?.id ?? decoded?.sub)?.toString() : null;
+  const clientId = decoded ? (decoded?.id ?? decoded?.sub ?? decoded?.creatorUserId)?.toString() : null;
   if (token && !clientId) {
     console.warn("❌ Token sans identifiant utilisateur.");
     window.location.href = "unauthorized.html";

--- a/server.express.js
+++ b/server.express.js
@@ -36,7 +36,7 @@ app.get('/validate', async (req, res) => {
   }
 
   const decoded = decodeJWT(token);
-  const clientId = decoded?.id?.toString();
+  const clientId = (decoded?.id ?? decoded?.sub ?? decoded?.creatorUserId)?.toString();
 
   if (!token || !decoded || !clientId) {
     return res.json({

--- a/server.js
+++ b/server.js
@@ -124,7 +124,7 @@ function revokeToken(token) {
 
 async function verifyExoToken(token) {
   const decoded = decodeJWT(token);
-  const clientId = (decoded?.id ?? decoded?.sub)?.toString();
+  const clientId = (decoded?.id ?? decoded?.sub ?? decoded?.creatorUserId)?.toString();
 
   if (!token || !decoded || !clientId || isTokenExpired(decoded)) {
     return { ok: false, reason: 'Token JWT invalide ou non décodable', decoded, clientId };

--- a/test.js
+++ b/test.js
@@ -99,6 +99,20 @@ async function testValidateSub() {
   assert.strictEqual(result.ok, true);
 }
 
+async function testValidateCreatorId() {
+  const payload = { creatorUserId: 555, exp: Math.floor(Date.now() / 1000) + 60 };
+  const token = createToken(payload);
+  const srv = await startServer();
+  setFetch(async () => ({
+    json: async () => ({ data: { me: { id: '555' } } })
+  }));
+
+  const result = await requestValidate(srv, token);
+  srv.close();
+  setFetch(undefined);
+  assert.strictEqual(result.ok, true);
+}
+
 async function testValidateExpiry() {
   fs.writeFileSync(revokedFile, '[]');
   _testing.revokedTokens.clear();
@@ -221,6 +235,7 @@ async function runTests() {
   testTokenExpiry();
   await testValidate(true);
   await testValidateSub();
+  await testValidateCreatorId();
   await testValidate(false);
   await testValidateExpiry();
   await testTokenReplacement();


### PR DESCRIPTION
## Summary
- accept tokens that provide `creatorUserId` as user identifier
- update express and browser-side validators for new field
- add tests for `creatorUserId`

## Testing
- `npm test`
- `node` (stub fetch, request /validate with creatorUserId token)

------
https://chatgpt.com/codex/tasks/task_e_68947ad90080832ca63ea1c45fe5d245