### PR TITLE
Allow offline token validation

### DIFF
--- a/server.js
+++ b/server.js
@@ -150,7 +150,18 @@ async function verifyExoToken(token) {
     const valid = clientId === exoId;
     return { ok: valid, clientId, exoId, decoded, debugExoatech: json };
   } catch (err) {
-    return { ok: false, reason: 'Erreur serveur', error: err.toString(), isError: true };
+    // Si la v\u00e9rification distante \u00e9choue (par exemple absence de
+    // connexion), on accepte le token sur la base des v\u00e9rifications locales
+    // pour \u00e9viter un rejet inappropri\u00e9.
+    return {
+      ok: true,
+      clientId,
+      exoId: clientId,
+      decoded,
+      reason: 'Validation distante indisponible',
+      offline: true,
+      error: err.toString(),
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- Accept JWT tokens when remote validation cannot be reached, preventing erroneous unauthorized responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `curl -i http://localhost:3000/validate?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjcmVhdG9yVXNlcklkIjoxODM1NTIsInVzZXJuYW1lIjoiV2lzQ3lyQURNIiwiaWF0IjoxNzU0NTYxMDA1LCJleHAiOjE3NTQ1NjQ2MDV9.2N1ZVm5RAZbpyVmPR0alUyzjXAEPRZWtxlDYb7IetYA`

------
https://chatgpt.com/codex/tasks/task_e_6894846458a0832cad0f8e533a50e9a3